### PR TITLE
Include depedency of pycocotools.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ install_requires =
     scipy>=1.4
     ruamel.yaml>=0.15
     matplotlib>=3.3.0
+    pycocotools>=2.0.0
 include_package_data = True
 
 [options.extras_require]


### PR DESCRIPTION
resolves #2 

Initially I tried to include the original repo with the subdirectory tag under  [setup.cfg](https://github.com/pmeletis/panoptic_parts/blob/788112d9fa505f0623093ce624ec7811ab559fd1/setup.cfg)
```ini
[options]
...
install_requires
    ...
    pycocotools @ git+https://github.com/cocodataset/cocoapi.git#egg=pycocotools&subdirectory=PythonAPI
    ...
```
however it became a bit tricky with both the involvement of gcc from pycocotools (the build has [dependency on the root directory](https://github.com/cocodataset/cocoapi/blob/8c9bcc3cf640524c4c20a9c40e89cb6a2f2fa0e9/PythonAPI/setup.py#L10) not just the subdirectory) and with pip editable install not properly supporting the pyproject.toml, while [numpy is required as a build_system requirement by pycocotools](https://github.com/cocodataset/cocoapi/blob/8c9bcc3cf640524c4c20a9c40e89cb6a2f2fa0e9/PythonAPI/setup.py#L2). 

So with searching on PyPI, bumped into this built package from a fork of the original repo with some improvement.

If there are no strict requirements on the original repo, it's worth trying out this built package, maybe with some tests that uses the `pycocotools` module?